### PR TITLE
Update flake.nix to use pkgs.gcc14Stdenv.mkDerivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     {
       packages = forHyprlandSystems
         (system: pkgs: rec {
-          hyprfocus = pkgs.gcc13Stdenv.mkDerivation {
+          hyprfocus = pkgs.gcc14Stdenv.mkDerivation {
             pname = "hyprfocus";
             version = "0.1";
             src = nix-filter.lib {


### PR DESCRIPTION
`gcc13Stdenv` is failing to build for me. So updating to `gcc14Stdenv`